### PR TITLE
Initialize Swrve plugin outside of the cordova platform directory

### DIFF
--- a/PhoneGap/SwrvePlugin/platforms/android/src/com/swrve/SwrvePlugin.java
+++ b/PhoneGap/SwrvePlugin/platforms/android/src/com/swrve/SwrvePlugin.java
@@ -3,9 +3,11 @@ package com.swrve;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
+import android.content.res.Resources;
 import android.os.Build;
 import android.os.Bundle;
 import android.util.Base64;
+import android.util.Log;
 import android.webkit.ValueCallback;
 
 import org.apache.cordova.engine.SystemWebView;
@@ -80,6 +82,7 @@ public class SwrvePlugin extends CordovaPlugin {
 
     @Override
     public void initialize(CordovaInterface cordova, CordovaWebView webView) {
+        createSwrveInstance();
         super.initialize(cordova, webView);
         // Activity started
         SwrveSDK.onCreate(cordova.getActivity());
@@ -87,6 +90,40 @@ public class SwrvePlugin extends CordovaPlugin {
         Map<String, String> userUpdateWrapperVersion = new HashMap<String, String>();
         userUpdateWrapperVersion.put("swrve.wrapper_version", VERSION);
         SwrveSDK.userUpdate(userUpdateWrapperVersion);
+    }
+
+    private void createSwrveInstance() {
+        SwrveConfig config = new SwrveConfig();
+        int appId = getAppIdFromResource("AppId");
+        String appKey = getResource("ApiKey");
+        SwrvePlugin.createInstance(cordova.getActivity().getApplicationContext(), appId, appKey, config);
+    }
+
+    private int getAppIdFromResource(String resourceName) {
+        String appId = getResource(resourceName);
+        try{
+            return Integer.parseInt(appId);
+        } catch (Exception ex) {
+            Log.e("SwrvePlugin", "AppId should be a number");
+        }
+
+        return 0;
+    }
+
+    private String getResource(String resourceName){
+        Activity context = cordova.getActivity();
+        Resources r = context.getResources();
+        String resourceValue = null;
+        int resource = locateResource(context, resourceName, "string");
+        if (resource != 0) {
+            resourceValue =  r.getString(resource);
+        }
+
+        return resourceValue;
+    }
+
+    private int locateResource(Activity context, String resourceName, String resourceType) {
+        return context.getResources().getIdentifier(resourceName, resourceType, context.getPackageName());
     }
 
     private HashMap<String, String> getMapFromJSON(JSONObject json) throws JSONException {

--- a/PhoneGap/SwrvePlugin/platforms/android/src/com/swrve/SwrvePlugin.java
+++ b/PhoneGap/SwrvePlugin/platforms/android/src/com/swrve/SwrvePlugin.java
@@ -96,6 +96,11 @@ public class SwrvePlugin extends CordovaPlugin {
         SwrveConfig config = new SwrveConfig();
         int appId = getAppIdFromResource("AppId");
         String appKey = getResource("ApiKey");
+        String senderId = getResource("SenderId");
+        if (!senderId.trim().isEmpty()) {
+            config.setSenderId(senderId);
+        }
+
         SwrvePlugin.createInstance(cordova.getActivity().getApplicationContext(), appId, appKey, config);
     }
 

--- a/PhoneGap/SwrvePlugin/platforms/ios/CDVAppDelegate+Swizzling.h
+++ b/PhoneGap/SwrvePlugin/platforms/ios/CDVAppDelegate+Swizzling.h
@@ -1,0 +1,4 @@
+#import "AppDelegate.h"
+
+@interface CDVAppDelegate (Swrve)
+@end

--- a/PhoneGap/SwrvePlugin/platforms/ios/CDVAppDelegate+Swizzling.m
+++ b/PhoneGap/SwrvePlugin/platforms/ios/CDVAppDelegate+Swizzling.m
@@ -1,0 +1,52 @@
+#import <objc/runtime.h>
+#import "AppDelegate.h"
+#import "Swrve.h"
+#import "SwrvePlugin.h"
+
+static void swizzleMethod(Class class, SEL destinationSelector, SEL sourceSelector);
+
+@implementation CDVAppDelegate (Swrve)
+
++ (void)load {
+    swizzleMethod([CDVAppDelegate class],
+        @selector(application:didFinishLaunchingWithOptions:),
+        @selector(my_application:didFinishLaunchingWithOptions:));
+
+    swizzleMethod([CDVAppDelegate class],
+        @selector(application:didReceiveRemoteNotification:),
+        @selector(my_application:didReceiveRemoteNotification:));
+}
+
+- (BOOL)my_application: (UIApplication*)application
+            didFinishLaunchingWithOptions:(NSDictionary*)launchOptions {
+    NSNumber *appId = NSBundle.mainBundle.infoDictionary[@"AppId"];
+    NSString *apiKey = NSBundle.mainBundle.infoDictionary[@"ApiKey"];
+    SwrveConfig* config = [[SwrveConfig alloc] init];
+    [SwrvePlugin initWithAppID:[appId intValue]
+                        apiKey:apiKey
+                        config:config
+                viewController:self.viewController
+                launchOptions:launchOptions];
+
+     return [self my_application:application didFinishLaunchingWithOptions:launchOptions];
+}
+
+-(void) my_application: (UIApplication*) application didReceiveRemoteNotification:(NSDictionary *)userInfo {
+    [SwrvePlugin application:application didReceiveRemoteNotification:userInfo];
+    [self my_application:application didReceiveRemoteNotification:userInfo];
+}
+@end
+
+#pragma mark Swizzling
+
+static void swizzleMethod(Class class, SEL destinationSelector, SEL sourceSelector) {
+    Method destinationMethod = class_getInstanceMethod(class, destinationSelector);
+    Method sourceMethod = class_getInstanceMethod(class, sourceSelector);
+
+    // If the method doesn't exist, add it.  If it does exist, replace it with the given implementation.
+    if (class_addMethod(class, destinationSelector, method_getImplementation(sourceMethod), method_getTypeEncoding(sourceMethod))) {
+        class_replaceMethod(class, destinationSelector, method_getImplementation(destinationMethod), method_getTypeEncoding(destinationMethod));
+    } else {
+        method_exchangeImplementations(destinationMethod, sourceMethod);
+    }
+}

--- a/PhoneGap/SwrvePlugin/plugin.xml
+++ b/PhoneGap/SwrvePlugin/plugin.xml
@@ -18,6 +18,11 @@
   		</feature>
   	</config-file>
 
+    <config-file target="res/values/strings.xml" parent="/*">
+			<string name="ApiKey" translatable="false">your_api_key</string>
+			<string name="AppId" translatable="false">your_app_id</string>
+		</config-file>
+
   	<source-file src="platforms/android/src/com/swrve/SwrvePlugin.java" target-dir="src/com/swrve/" />
   	<framework src="platforms/android/build.gradle" custom="true" type="gradleReference" />
 
@@ -37,6 +42,15 @@
         <param name="onload" value="true" />
       </feature>
     </config-file>
+    <config-file target="*-Info.plist" parent="ApiKey">
+			<string>your_api_key</string>
+		</config-file>
+		<config-file target="*-Info.plist" parent="AppId">
+			<integer>your_app_id</integer>
+		</config-file>
+
+    <header-file src="platforms/ios/CDVAppDelegate+Swizzling.h" />
+    <source-file src="platforms/ios/CDVAppDelegate+Swizzling.m" />
 
     <header-file src="platforms/ios/SwrvePlugin.h" />
     <source-file src="platforms/ios/SwrvePlugin.m" />
@@ -166,6 +180,5 @@
     <source-file src="platforms/ios/SwrveSDK/SwrveSDK/SDK/Track/SwrveResourceManager.m" target-dir="SwrveSDK/SDK/Track/SwrveResourceManager.m"/>
     <header-file src="platforms/ios/SwrveSDK/SwrveSDK/SDK/Track/SwrveSwizzleHelper.h" target-dir="SwrveSDK/SDK/Track/SwrveSwizzleHelper.h"/>
     <source-file src="platforms/ios/SwrveSDK/SwrveSDK/SDK/Track/SwrveSwizzleHelper.m" target-dir="SwrveSDK/SDK/Track/SwrveSwizzleHelper.m"/>
-
   </platform>
 </plugin>

--- a/PhoneGap/SwrvePlugin/plugin.xml
+++ b/PhoneGap/SwrvePlugin/plugin.xml
@@ -6,36 +6,38 @@
   <license>Apache 2.0</license>
   <keywords>swrve,analytics,messaging</keywords>
 
-  <preference name="APP_ID" default="1"/>
-	<preference name="API_KEY" default="Your_Api_Key"/>
+  <preference name="APP_ID" />
+  <preference name="API_KEY" />
+  <preference name="SENDER_ID" default=" "/>
 
-	<platform name="android">
+  <platform name="android">
     <js-module src="js/swrve-android.js" name="SwrvePlugin">
       <clobbers target="SwrvePlugin"/>
     </js-module>
 
     <config-file target="res/xml/config.xml" parent="/*">
-  	  <feature name="SwrvePlugin">
-  		  <param name="android-package" value="com.swrve.SwrvePlugin"/>
+      <feature name="SwrvePlugin">
+        <param name="android-package" value="com.swrve.SwrvePlugin"/>
         <param name="onload" value="true" />
-  		</feature>
-  	</config-file>
+      </feature>
+    </config-file>
 
     <config-file target="res/values/strings.xml" parent="/*">
-			<string name="ApiKey" translatable="false">$API_KEY</string>
-			<string name="AppId" translatable="false">$APP_ID</string>
-		</config-file>
+      <string name="ApiKey" translatable="false">$API_KEY</string>
+      <string name="AppId" translatable="false">$APP_ID</string>
+      <string name="SenderId" translatable="false">$SENDER_ID</string>
+    </config-file>
 
-  	<source-file src="platforms/android/src/com/swrve/SwrvePlugin.java" target-dir="src/com/swrve/" />
-  	<framework src="platforms/android/build.gradle" custom="true" type="gradleReference" />
+    <source-file src="platforms/android/src/com/swrve/SwrvePlugin.java" target-dir="src/com/swrve/" />
+    <framework src="platforms/android/build.gradle" custom="true" type="gradleReference" />
 
     <config-file target="AndroidManifest.xml" parent="/manifest">
       <uses-permission android:name="android.permission.INTERNET"/>
       <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
     </config-file>
-	</platform>
+  </platform>
 
-	<platform name="ios">
+  <platform name="ios">
     <js-module src="js/swrve-ios.js" name="SwrvePlugin">
       <clobbers target="SwrvePlugin"/>
     </js-module>
@@ -47,11 +49,11 @@
     </config-file>
 
     <config-file target="*-Info.plist" parent="ApiKey">
-			<string>$API_KEY</string>
-		</config-file>
-		<config-file target="*-Info.plist" parent="AppId">
-			<integer>$APP_ID</integer>
-		</config-file>
+      <string>$API_KEY</string>
+    </config-file>
+    <config-file target="*-Info.plist" parent="AppId">
+      <integer>$APP_ID</integer>
+    </config-file>
 
     <header-file src="platforms/ios/CDVAppDelegate+Swizzling.h" />
     <source-file src="platforms/ios/CDVAppDelegate+Swizzling.m" />

--- a/PhoneGap/SwrvePlugin/plugin.xml
+++ b/PhoneGap/SwrvePlugin/plugin.xml
@@ -6,6 +6,9 @@
   <license>Apache 2.0</license>
   <keywords>swrve,analytics,messaging</keywords>
 
+  <preference name="APP_ID" default="1"/>
+	<preference name="API_KEY" default="Your_Api_Key"/>
+
 	<platform name="android">
     <js-module src="js/swrve-android.js" name="SwrvePlugin">
       <clobbers target="SwrvePlugin"/>
@@ -19,8 +22,8 @@
   	</config-file>
 
     <config-file target="res/values/strings.xml" parent="/*">
-			<string name="ApiKey" translatable="false">your_api_key</string>
-			<string name="AppId" translatable="false">your_app_id</string>
+			<string name="ApiKey" translatable="false">$API_KEY</string>
+			<string name="AppId" translatable="false">$APP_ID</string>
 		</config-file>
 
   	<source-file src="platforms/android/src/com/swrve/SwrvePlugin.java" target-dir="src/com/swrve/" />
@@ -42,11 +45,12 @@
         <param name="onload" value="true" />
       </feature>
     </config-file>
+
     <config-file target="*-Info.plist" parent="ApiKey">
-			<string>your_api_key</string>
+			<string>$API_KEY</string>
 		</config-file>
 		<config-file target="*-Info.plist" parent="AppId">
-			<integer>your_app_id</integer>
+			<integer>$APP_ID</integer>
 		</config-file>
 
     <header-file src="platforms/ios/CDVAppDelegate+Swizzling.h" />


### PR DESCRIPTION
### Plugin.xml
Introduced new plugin variables `APP_ID`, `API_KEY` and `SENDER_ID`. `SENDER_ID`  is optional variable only for Android and set the sender id for Google GCM configuration in the SwrveConfig. 
Store the plugin variables value in `strings.xml` for android and `*.plist` for iOS.


### Android
* Initialize Swrve SDK just before plugin initialization in `SwrvePlugin.java`.
* Provide a way to extract plugin variables from the `strings.xml` resource file.

### iOS
* Create class that swizzle CDVAppDelegate methods:
  * `application:didFinishLaunchingWithOptions:`
    * Used for Swrve SDK initialization.
  * `application:didReceiveRemoteNotification:` 
    * Used for subscribing to push notification.

####
Example of instalation:
```
cordova plugin add ./SwrvePlugin --variable APP_ID=<your_app_id> --variable API_KEY=<your_api_key> --variable SENDER_ID=<your_sender_id>
```
